### PR TITLE
Fix tests: removed dupe word "better".

### DIFF
--- a/words.ts
+++ b/words.ts
@@ -372,7 +372,6 @@ export const wordList = {
     { word: "beefy", categories: ["appearance"] },
     { word: "belligerent", categories: ["personality"] },
     { word: "bent", categories: ["condition"] },
-    { word: "better", categories: ["condition"] },
     { word: "best", categories: ["condition"] },
     { word: "better", categories: ["condition"] },
     { word: "bewildered", categories: ["personality"] },


### PR DESCRIPTION
Fixing this error on `npm run test` : 

```
 FAIL  test/randomWordSlugs.test.ts
  wordList
    ✕ has no repeats
  generateSlug
    ✓ generates three random kebab-cased words by default (165 ms)
    ✓ generates four random kebab-cased words if requested (178 ms)
    ✓ allows user to specify word categories (150 ms)
    ✓ should format as camelCase (228 ms)
    ✓ should format as Title Case (202 ms)
    ✓ should format as lower case (198 ms)
    ✓ should format as Sentence case (202 ms)
  totalUniqueSlugs
    ✓ should tally up total slugs
    ✓ should tally slugs in subset of categories (1 ms)

  ● wordList › has no repeats

    Some words are repeated: {"noun":[],"adjective":["better"]}

      58 |
      59 |     if (repeats.noun.length || repeats.adjective.length) {
    > 60 |       throw new Error(`Some words are repeated: ${JSON.stringify(repeats)}`);
         |             ^
      61 |     }
      62 |   });
      63 | });

      at Object.<anonymous> (test/randomWordSlugs.test.ts:60:13)
```